### PR TITLE
Added test for logout controller

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha",
     "dev": "nodemon ./bin/www"
   },
   "dependencies": {

--- a/server/test/ping.spec.js
+++ b/server/test/ping.spec.js
@@ -1,21 +1,18 @@
 const chai = require("chai");
 const chaiHttp = require("chai-http");
-const app = require("../app.js");
+const { app } = require("../app.js");
 
 chai.should();
 chai.use(chaiHttp);
 
-describe("/POST ping", () => {
-  it("it should return 200 and message", (done) => {
+describe("/POST /auth/logout", () => {
+  it("should return status 200", (done) => {
     chai
       .request(app)
-      .post(`/ping/`)
-      .send({ message: "hello" })
+      .post("/auth/logout")
+      .send()
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.have
-          .property("response")
-          .eql("Server is running. Message received: hello");
         done();
       });
   });


### PR DESCRIPTION
### What this PR does (required):
- added test on route `/auth/logout` to see if it return a successful response


### Any information needed to test this feature (required):
- In `/server` directory, run command `npm test`
- You will see test with name _**/POST /auth/logout**_ and result of test

Link to ticket https://hatchways.notion.site/Add-tests-for-logout-controller-76f28b495ba14a7eab6732992f15fdeb
